### PR TITLE
guard serializerOptions (can be undefined)

### DIFF
--- a/lib/adapters/bookshelf.js
+++ b/lib/adapters/bookshelf.js
@@ -19,7 +19,7 @@ function BookshelfAdapter(data, type, baseUrl, serializerOptions, options) {
   options = _.assign({}, options);
 
   // Add any meta data passed in serializerOptions.
-  if (serializerOptions.meta) {
+  if (serializerOptions && serializerOptions.meta) {
     template.meta = serializerOptions.meta;
   }
 
@@ -78,7 +78,7 @@ function BookshelfAdapter(data, type, baseUrl, serializerOptions, options) {
     if (options.includeRelations !== undefined) {
       included = options.includeRelations;
     } else {
-      included = serializerOptions.include;
+      included = serializerOptions && serializerOptions.include;
     }
 
     var relationAttributes = null,


### PR DESCRIPTION
The bookshelf serializer breaks when no serializer options are given, like in the example (thus, undefined and making errors).